### PR TITLE
fix(SES-521): Call field formatter directly instead of toString().

### DIFF
--- a/common/table_filter.js
+++ b/common/table_filter.js
@@ -25,7 +25,8 @@ function isBucket(field) {
 }
 
 function fieldMatches(field, search) {
-  const fieldLower = field.toString().toLowerCase();
+  const fieldFormatter = field.aggConfig.fieldFormatter('text');
+  const fieldLower = fieldFormatter(field.value).toLowerCase();
   const searchLower = search.toLowerCase();
   return fieldLower.includes(searchLower);
 }


### PR DESCRIPTION
This change fixes a regression of SES-521. field.toString() inexplicably formats the field, then un-formats it before returning it. We have to call the fieldFormatter API directly.